### PR TITLE
グラフ描画機能の微修正

### DIFF
--- a/dmm/dmm_plot.py
+++ b/dmm/dmm_plot.py
@@ -211,6 +211,7 @@ class PlotFig():
             self.draw_line(e,label="error",color="b",num=args.obs_num_particle)
             plt.legend()
             plt.title("error")
+            plt.tight_layout()
         else:
 
             plt.subplot(2, 1, 1)
@@ -221,6 +222,7 @@ class PlotFig():
             
             plt.subplot(2, 1, 2)
             self.plot_x(args,idx,s,data)
+            plt.tight_layout()
             if args.anim:
                 h=data.x.shape[2]
                 if args.x_plot_type=="line":


### PR DESCRIPTION
dmm-plotで2段, 3段のグラフを描画すると, 上段のグラフの目盛りと下段のグラフのタイトルが重なる問題を解消しました.

参考：https://matplotlib.org/3.2.2/api/_as_gen/matplotlib.pyplot.tight_layout.html